### PR TITLE
S3 sync cleanup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ FULCRUM_S3_SYNC_ENABLED=yes|no                  # default no
 FULCRUM_AWS_ACCESS_KEY_ID="<key id>"            # key
 FULCRUM_AWS_SECRET_ACCESS_KEY="<secret>"        # secret
 FULCRUM_S3_SYNC_BUCKET="<bucket>"               # can also be in the form "bucket/sub-folder"
-FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED=yes # This option will delete files from S3 which dont exist locally... Be careful.
+FULCRUM_S3_SYNC_ARGS=      # You can specify aws s3 sync options which get
+                           # passed to the AWS cli command.
 ```
 
 ### Fulcrum Backup

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ FULCRUM_S3_SYNC_ENABLED=yes|no                  # default no
 FULCRUM_AWS_ACCESS_KEY_ID="<key id>"            # key
 FULCRUM_AWS_SECRET_ACCESS_KEY="<secret>"        # secret
 FULCRUM_S3_SYNC_BUCKET="<bucket>"               # can also be in the form "bucket/sub-folder"
+FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED=yes # This option will delete files from S3 which dont exist locally... Be careful.
 ```
 
 ### Fulcrum Backup

--- a/scripts/start
+++ b/scripts/start
@@ -30,6 +30,7 @@ export FULCRUM_MSSQL_ENABLED=${FULCRUM_MSSQL_ENABLED:=no}
 export FULCRUM_MSSQL_ARGS=${FULCRUM_MSSQL_ARGS:=""}
 
 export FULCRUM_S3_SYNC_ENABLED=${FULCRUM_S3_SYNC_ENABLED:=no}
+export FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED=${FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED:=no}
 
 # assign the awscli-specific variables
 export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$FULCRUM_AWS_ACCESS_KEY_ID}
@@ -146,5 +147,10 @@ if [[ $FULCRUM_S3_SYNC_ENABLED != "no" ]]; then
     error "FULCRUM_S3_SYNC_BUCKET required for s3 sync"
   fi
 
-  /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET
+  if [[ $FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED != "no" ]]; then
+      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET
+  else
+      echo "S3 Destination Cleanup is enabled... Deleting files which dont exist locally"
+      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET --delete
+  fi
 fi

--- a/scripts/start
+++ b/scripts/start
@@ -147,10 +147,10 @@ if [[ $FULCRUM_S3_SYNC_ENABLED != "no" ]]; then
     error "FULCRUM_S3_SYNC_BUCKET required for s3 sync"
   fi
 
-  if [[ $FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED != "no" ]]; then
-      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET
-  else
+  if [[ $FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED == "yes" ]]; then
       echo "S3 Destination Cleanup is enabled... Deleting files which dont exist locally"
-      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET --delete
+      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET --delete      
+  else
+      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET
   fi
 fi

--- a/scripts/start
+++ b/scripts/start
@@ -30,7 +30,7 @@ export FULCRUM_MSSQL_ENABLED=${FULCRUM_MSSQL_ENABLED:=no}
 export FULCRUM_MSSQL_ARGS=${FULCRUM_MSSQL_ARGS:=""}
 
 export FULCRUM_S3_SYNC_ENABLED=${FULCRUM_S3_SYNC_ENABLED:=no}
-export FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED=${FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED:=no}
+export FULCRUM_S3_SYNC_ARGS=${FULCRUM_S3_SYNC_ARGS:=""}
 
 # assign the awscli-specific variables
 export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$FULCRUM_AWS_ACCESS_KEY_ID}
@@ -147,10 +147,5 @@ if [[ $FULCRUM_S3_SYNC_ENABLED != "no" ]]; then
     error "FULCRUM_S3_SYNC_BUCKET required for s3 sync"
   fi
 
-  if [[ $FULCRUM_S3_SYNC_DESTINATION_CLEANUP_ENABLED == "yes" ]]; then
-      echo "S3 Destination Cleanup is enabled... Deleting files which dont exist locally"
-      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET --delete      
-  else
-      /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET
-  fi
+  /usr/local/bin/aws s3 sync /data s3://$FULCRUM_S3_SYNC_BUCKET $FULCRUM_S3_SYNC_ARGS
 fi


### PR DESCRIPTION
Added an optional S3_ARGS attribute which will allow users to pass S3 sync options to the command.

This is needed to allow for cleaning up data in S3 which might no longer exist in Fulcrum.